### PR TITLE
bug in startup for curson scene

### DIFF
--- a/cursorscene.ts
+++ b/cursorscene.ts
@@ -93,7 +93,8 @@ namespace user_interface_base {
 
             this.cursor = new Cursor()
             this.picker = new Picker(this.cursor)
-            this.navigator = new RowNavigator()
+            if (this.navigator == null)
+                this.navigator = new RowNavigator()
             this.cursor.navigator = this.navigator
         }
 


### PR DESCRIPTION
In the cursorScene startup function it sets the navigator variable to be a row navigator, this overrides the existing navigator which may or may not be set by the constructor. This change makes it check it is null before setting it, in line with how cursorSceneWithPriorPage acts in startup.

I tested this with microcode, and it did not throw any errors, though I was unable to check it with the editor as it seems to currently be throwing 980 for a value being undefined.